### PR TITLE
feat(config): configura estrutura de pacotes para Spring Boot

### DIFF
--- a/src/main/java/dev/ramillers/Get/it/done/Application.java
+++ b/src/main/java/dev/ramillers/Get/it/done/Application.java
@@ -2,15 +2,17 @@ package dev.ramillers.Get.it.done;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.context.annotation.ComponentScan;
-
-@ComponentScan(basePackages = "dev.ramillers.Get.it.done")
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 
 @SpringBootApplication
+@ComponentScan(basePackages = {"dev.ramillers.Get.it.done", "service", "repository"})
+@EnableJpaRepositories(basePackages = "repository")
+@EntityScan("dev.ramillers.Get.it.done.model")
 public class Application {
 
-	public static void main(String[] args) {
-		SpringApplication.run(Application.class, args);
-	}
-
+    public static void main(String[] args) {
+        SpringApplication.run(Application.class, args);
+    }
 }


### PR DESCRIPTION
# 🚀 feat(config): Configura estrutura de pacotes para Spring Boot

## 🔧 O que foi feito?
- ✅ Adicionada a anotação `@ComponentScan` para incluir os pacotes `"service"` e `"repository"`, garantindo que os componentes sejam detectados pelo Spring.  
- ✅ Configurada a anotação `@EnableJpaRepositories`, apontando para o pacote `"repository"`, permitindo que o Spring gerencie corretamente os repositórios JPA.  
- ✅ Definida a anotação `@EntityScan` para localizar entidades no pacote `"model"`, assegurando que o Spring reconheça corretamente as classes de entidade.  

## 💡 Por que essa mudança?
Por padrão, o Spring Boot escaneia apenas pacotes dentro do diretório principal da aplicação. Como a estrutura utilizada não segue essa convenção, foi necessário configurar manualmente os pacotes que contêm **componentes**, **repositórios** e **entidades**.  

Com essas configurações, garantimos que:  
✔️ Os **serviços** e **repositórios** sejam encontrados corretamente.  
✔️ As **entidades** sejam reconhecidas pelo JPA.  
✔️ O Spring Boot consiga gerenciar todos os componentes da aplicação, mesmo fora da estrutura padrão.  
